### PR TITLE
fix: proposals for span ids

### DIFF
--- a/xsl/propose_spans.xsl
+++ b/xsl/propose_spans.xsl
@@ -24,11 +24,21 @@
         <xsl:variable 
             name="maximum" 
             as="xs:double?"
-            select="
-            $doc//tei:*[./name() = $context-name]/replace(@spanTo, '\w+(\d)+', '$1')
-            => max()
-            => number()
-            "/>
+            >
+            <xsl:variable 
+                name="spans" 
+                as="xs:string*" 
+                select=" $doc//tei:*[./name() = $context-name][matches(@spanTo, '\w+(\d)+')]/replace(@spanTo, '\w+(\d)+', '$1')"
+            />
+            <xsl:if test="$spans">
+                <xsl:sequence 
+                    select="
+                    $spans
+                    => max()
+                    => number()"
+                />
+            </xsl:if>
+        </xsl:variable>
         <xsl:variable name="prefix" select="$context-name => substring-before('Span')"/>
         <items>
             <item value="{if (exists($maximum)) then $prefix || $maximum + 1 else $prefix || '1'}"/>


### PR DESCRIPTION
This commit fixes the proposal for span ids. This behaviour was buggy,
when there were no other 'spans' of the same type. The script propsed
'nameNaN' before, because it used the empty value of the context and
tried to extract a number (which did not exist yet).
