### PR TITLE
v1.1.0

### DIFF
--- a/stylesheets/elements/head.less
+++ b/stylesheets/elements/head.less
@@ -6,8 +6,16 @@ head {
     font-weight: bold;
 }
 
+head[n]::before {
+    content: attr(n) ". ";
+}
+
 head[resp]::before {
     content: "[";
+}
+
+head[n][resp]::before {
+    content: "[" attr(n) ". ";
 }
 
 head[resp]::after {

--- a/stylesheets/elements/idno.less
+++ b/stylesheets/elements/idno.less
@@ -33,3 +33,8 @@ TEI[xml|lang = 'fr'] altIdentifier idno::before {
     content: "Signature alternative : ";
     .additional-text;
 }
+
+msIdentifier idno[source]:hover::after, altIdentifier idno[source]:hover::after {
+    content: " (" attr(source) ")";
+    -oxy-link: attr(source);
+}

--- a/stylesheets/elements/origPlace.less
+++ b/stylesheets/elements/origPlace.less
@@ -9,23 +9,27 @@ origPlace {
 TEI[xml|lang = "de"] origPlace::before {
     // ToDo: Finale API-URL einfügen!
     content: "Ausstellungsort (" attr(type) ") (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=de')") ") ";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
     .additional-text;
 }
 
 TEI[xml|lang = "fr"] origPlace::before {
     // ToDo: Finale API-URL einfügen!
     content: "Lieu d'exposition (" attr(type) ") (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ") ";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
     .additional-text;
 }
 
 TEI[xml|lang = "de"] origPlace[cert]::before {
     // ToDo: Finale API-URL einfügen!
     content: "Ausstellungsort (" attr(type) ") (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=de')") ") [" attr(cert) "] ";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
     .additional-text;
 }
 
 TEI[xml|lang = "fr"] origPlace[cert]::before {
     // ToDo: Finale API-URL einfügen!
     content: "Lieu d'exposition (" attr(type) ") (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ") [" attr(cert) "] ";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
     .additional-text;
 }

--- a/stylesheets/elements/pb.less
+++ b/stylesheets/elements/pb.less
@@ -1,3 +1,16 @@
 pb {
     content: "\A // [" attr(n) "] ";
 }
+
+TEI[xml|lang = "de"] pb[facs]:hover::after {
+    content: "Faksimile «" attr(facs) "» öffnen";
+    -oxy-link: "https://facsimiles.ssrq-sds-fds.ch/iiif/2/" attr(facs) ".ptif/full/full/0/default.jpg";
+    text-decoration: underline;
+}
+
+TEI[xml|lang = "fr"] pb[facs]:hover::after {
+    content: "Ouvrez le fac-similé « " attr(facs) " »";
+    -oxy-link: "https://facsimiles.ssrq-sds-fds.ch/iiif/2/" attr(facs) ".ptif/full/full/0/default.jpg";
+    text-decoration: underline;
+}
+

--- a/stylesheets/elements/pb.less
+++ b/stylesheets/elements/pb.less
@@ -5,12 +5,12 @@ pb {
 TEI[xml|lang = "de"] pb[facs]:hover::after {
     content: "Faksimile «" attr(facs) "» öffnen";
     -oxy-link: "https://facsimiles.ssrq-sds-fds.ch/iiif/2/" attr(facs) ".ptif/full/full/0/default.jpg";
-    text-decoration: underline;
+    .additional-text;
 }
 
 TEI[xml|lang = "fr"] pb[facs]:hover::after {
     content: "Ouvrez le fac-similé « " attr(facs) " »";
     -oxy-link: "https://facsimiles.ssrq-sds-fds.ch/iiif/2/" attr(facs) ".ptif/full/full/0/default.jpg";
-    text-decoration: underline;
+    .additional-text;
 }
 

--- a/stylesheets/elements/persName.less
+++ b/stylesheets/elements/persName.less
@@ -7,9 +7,11 @@ persName {
 TEI[xml|lang = "de"] persName[ref]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/persons/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 
 TEI[xml|lang = "fr"] persName[ref]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/persons/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }

--- a/stylesheets/elements/placeName.less
+++ b/stylesheets/elements/placeName.less
@@ -7,9 +7,11 @@ placeName {
 TEI[xml|lang = "de"] placeName[ref]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 
 TEI[xml|lang = "fr"] placeName[ref]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }

--- a/stylesheets/elements/pubPlace.less
+++ b/stylesheets/elements/pubPlace.less
@@ -7,9 +7,11 @@ pubPlace {
 TEI[xml|lang = "de"] pubPlace[ref]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 
 TEI[xml|lang = "fr"] pubPlace[ref]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }

--- a/stylesheets/elements/seg.less
+++ b/stylesheets/elements/seg.less
@@ -7,4 +7,5 @@ seg {
 
 seg[n]::before {
     content: "[" attr(n) "]";
+    margin-right: @tiny-size;
 }

--- a/stylesheets/elements/term.less
+++ b/stylesheets/elements/term.less
@@ -9,24 +9,28 @@ TEI[xml|lang = "de"] term[ref^="key"]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID: " attr(ref) "; Standardname: "
     oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/keywords/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 
 TEI[xml|lang = "fr"] term[ref^="key"]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID : " attr(ref) "; Nom standard : "
     oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/keywords/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 
 TEI[xml|lang = "de"] term[ref^="lem"]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID: " attr(ref) "; Standardname: "
     oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/lemmata/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 
 TEI[xml|lang = "fr"] term[ref^="lem"]:hover::after {
     // ToDo: Finale API-URL einfügen!
     content: " (ID : " attr(ref) "; Nom standard : "
     oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/lemmata/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+    -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 
 keywords term {

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -875,12 +875,12 @@ pb {
 TEI[xml|lang="de"] pb[facs]:hover::after {
   content: "Faksimile «" attr(facs) "» öffnen";
   -oxy-link: "https://facsimiles.ssrq-sds-fds.ch/iiif/2/" attr(facs) ".ptif/full/full/0/default.jpg";
-  text-decoration: underline;
+  font-style: italic;
 }
 TEI[xml|lang="fr"] pb[facs]:hover::after {
   content: "Ouvrez le fac-similé « " attr(facs) " »";
   -oxy-link: "https://facsimiles.ssrq-sds-fds.ch/iiif/2/" attr(facs) ".ptif/full/full/0/default.jpg";
-  text-decoration: underline;
+  font-style: italic;
 }
 persName {
   color: #0000ff;

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -866,6 +866,16 @@ p {
 pb {
   content: "\A // [" attr(n) "] ";
 }
+TEI[xml|lang="de"] pb[facs]:hover::after {
+  content: "Faksimile «" attr(facs) "» öffnen";
+  -oxy-link: "https://facsimiles.ssrq-sds-fds.ch/iiif/2/" attr(facs) ".ptif/full/full/0/default.jpg";
+  text-decoration: underline;
+}
+TEI[xml|lang="fr"] pb[facs]:hover::after {
+  content: "Ouvrez le fac-similé « " attr(facs) " »";
+  -oxy-link: "https://facsimiles.ssrq-sds-fds.ch/iiif/2/" attr(facs) ".ptif/full/full/0/default.jpg";
+  text-decoration: underline;
+}
 persName {
   color: #0000ff;
 }

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -471,8 +471,14 @@ head {
   font-size: 20px;
   font-weight: bold;
 }
+head[n]::before {
+  content: attr(n) ". ";
+}
 head[resp]::before {
   content: "[";
+}
+head[n][resp]::before {
+  content: "[" attr(n) ". ";
 }
 head[resp]::after {
   content: "]";

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -1062,6 +1062,7 @@ seg {
 }
 seg[n]::before {
   content: "[" attr(n) "]";
+  margin-right: 6px;
 }
 seriesStmt {
   display: block;

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -588,6 +588,11 @@ TEI[xml|lang='fr'] altIdentifier idno::before {
   content: "Signature alternative : ";
   font-style: italic;
 }
+msIdentifier idno[source]:hover::after,
+altIdentifier idno[source]:hover::after {
+  content: " (" attr(source) ")";
+  -oxy-link: attr(source);
+}
 item {
   display: list-item;
   padding: 6px;

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -856,18 +856,22 @@ origPlace {
 }
 TEI[xml|lang="de"] origPlace::before {
   content: "Ausstellungsort (" attr(type) ") (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=de')") ") ";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
   font-style: italic;
 }
 TEI[xml|lang="fr"] origPlace::before {
   content: "Lieu d'exposition (" attr(type) ") (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ") ";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
   font-style: italic;
 }
 TEI[xml|lang="de"] origPlace[cert]::before {
   content: "Ausstellungsort (" attr(type) ") (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=de')") ") [" attr(cert) "] ";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
   font-style: italic;
 }
 TEI[xml|lang="fr"] origPlace[cert]::before {
   content: "Lieu d'exposition (" attr(type) ") (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ") [" attr(cert) "] ";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
   font-style: italic;
 }
 p {
@@ -892,9 +896,11 @@ persName {
 }
 TEI[xml|lang="de"] persName[ref]:hover::after {
   content: " (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/persons/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 TEI[xml|lang="fr"] persName[ref]:hover::after {
   content: " (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/persons/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 physDesc {
   display: block;
@@ -912,9 +918,11 @@ placeName {
 }
 TEI[xml|lang="de"] placeName[ref]:hover::after {
   content: " (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 TEI[xml|lang="fr"] placeName[ref]:hover::after {
   content: " (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 precision {
   content: "";
@@ -952,9 +960,11 @@ pubPlace {
 }
 TEI[xml|lang="de"] pubPlace[ref]:hover::after {
   content: " (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 TEI[xml|lang="fr"] pubPlace[ref]:hover::after {
   content: " (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/places/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 q {
   color: #808000;
@@ -1195,15 +1205,19 @@ term {
 }
 TEI[xml|lang="de"] term[ref^="key"]:hover::after {
   content: " (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/keywords/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 TEI[xml|lang="fr"] term[ref^="key"]:hover::after {
   content: " (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/keywords/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 TEI[xml|lang="de"] term[ref^="lem"]:hover::after {
   content: " (ID: " attr(ref) "; Standardname: " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/lemmata/' || substring(./@ref, 1, 9) || '/name?lang=de')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 TEI[xml|lang="fr"] term[ref^="lem"]:hover::after {
   content: " (ID : " attr(ref) "; Nom standard : " oxy_xpath("json-doc('https://staging.editio.ssrq-online.ch/api/v1/entities/lemmata/' || substring(./@ref, 1, 9) || '/name?lang=fr')") ")";
+  -oxy-link: "https://p.ssrq-sds-fds.ch/" oxy_xpath("substring(./@ref, 1, 9)");
 }
 keywords term {
   display: list-item;

--- a/test.xml
+++ b/test.xml
@@ -362,6 +362,9 @@
                             /></date>
                     </p>
                 </div>
+                <div>
+                    <p><lb/>Test für einen Abschnitt mit Line<lb break="no"/>beginning und break 'no'.</p>
+                </div>
                 <div type="section" n="5">
                     <head>Sonstige Auszeichnungen</head>
                     <p> Fremdsprachlicher Text: <foreign xml:lang="la"


### PR DESCRIPTION
Enthält Links mit Bezug zu: https://redmine.ssrq-sds-fds.ch/versions/34

- **test: Beispiel für lb und break = 'no'**
- **feat: klickbare Links für tei:pb mit facs-Attribut**
- **feat: Ausgabe des Attributs n für tei:head**
- **fix: Darstellung "Faksimile-Link" kursiv statt unterstrichen**
- **feat: Klickbare Links für Archivsignaturen**
- **fix: mehr Luft für die seg-Nummerierung**
- **feat: Klickbare Links für Entitäten in Autorenmodus**
