### PR TITLE
fix: tables

### DIFF
--- a/stylesheets/elements/cell.less
+++ b/stylesheets/elements/cell.less
@@ -1,3 +1,4 @@
+@import "../commons/colors.less";
 @import "../commons/sizes.less";
 
 cell {
@@ -19,4 +20,22 @@ cell[rend = 'align-bottom'] {
 
 cell:last-of-type {
     border-right: none;
+}
+
+row:nth-of-type(even) > cell {
+    background-color: @even-background-color;
+}
+
+row:nth-of-type(odd) > cell {
+    background-color: @odd-background-color;
+}
+
+/* show a serialized version of heads inside a table,
+ * which are not the first head (this is displayed as
+ * a table caption) of the table. Implemented as tables
+ * only support a single table-caption. */
+row > cell:first-of-type:before {
+  color: red;
+  content: oxy_xpath("if (parent::row/preceding-sibling::*[1][self::head and not(. is ancestor::table/head[1])]) then concat(serialize(parent::row/preceding-sibling::*[1]), '\a ') else ''");
+  margin: @small-size 0px @small-size 0px;
 }

--- a/stylesheets/elements/head.less
+++ b/stylesheets/elements/head.less
@@ -30,7 +30,11 @@ list head {
     margin: 0px 0px @small-size -@huge-size;
 }
 
-table head {
+table > head {
+    display: none;
+}
+
+table > head:first-of-type {
     display: table-caption;
     margin-bottom: @small-size;
 }

--- a/stylesheets/elements/row.less
+++ b/stylesheets/elements/row.less
@@ -1,17 +1,7 @@
-@import "../commons/colors.less";
-
 row {
     display: table-row;
 }
 
 row:has(> measureGrp) {
     display: table-row-group;
-}
-
-row:nth-of-type(even) {
-    background-color: @even-background-color;
-}
-
-row:nth-of-type(odd) {
-    background-color: @odd-background-color;
 }

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -217,6 +217,21 @@ cell[rend='align-bottom'] {
 cell:last-of-type {
   border-right: none;
 }
+row:nth-of-type(even) > cell {
+  background-color: #dddddd;
+}
+row:nth-of-type(odd) > cell {
+  background-color: #eeeeee;
+}
+/* show a serialized version of heads inside a table,
+ * which are not the first head (this is displayed as
+ * a table caption) of the table. Implemented as tables
+ * only support a single table-caption. */
+row > cell:first-of-type:before {
+  color: red;
+  content: oxy_xpath("if (parent::row/preceding-sibling::*[1][self::head and not(. is ancestor::table/head[1])]) then concat(serialize(parent::row/preceding-sibling::*[1]), '\a ') else ''");
+  margin: 10px 0px 10px 0px;
+}
 choice {
   display: contents;
 }
@@ -503,7 +518,10 @@ msDesc head {
 list head {
   margin: 0px 0px 10px -24px;
 }
-table head {
+table > head {
+  display: none;
+}
+table > head:first-of-type {
   display: table-caption;
   margin-bottom: 10px;
 }
@@ -1106,12 +1124,6 @@ row {
 }
 row:has(> measureGrp) {
   display: table-row-group;
-}
-row:nth-of-type(even) {
-  background-color: #dddddd;
-}
-row:nth-of-type(odd) {
-  background-color: #eeeeee;
 }
 seal {
   display: block;


### PR DESCRIPTION
- this commit fixes the background coloring of odd and even table rows
- this commit fixes the vanishing of multiple heads by displaying them as table-caption (first head) or serialized content (second until nth head)